### PR TITLE
Fix REI compatability

### DIFF
--- a/src/main/java/wraith/fabricaeexnihilo/compatibility/rei/sieve/SieveDisplay.java
+++ b/src/main/java/wraith/fabricaeexnihilo/compatibility/rei/sieve/SieveDisplay.java
@@ -9,9 +9,10 @@ import wraith.fabricaeexnihilo.compatibility.recipeviewer.SieveRecipeKey;
 import wraith.fabricaeexnihilo.compatibility.recipeviewer.SieveRecipeOutputs;
 import wraith.fabricaeexnihilo.compatibility.rei.PluginEntry;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class SieveDisplay implements Display {
     public final boolean waterlogged;
@@ -23,11 +24,10 @@ public class SieveDisplay implements Display {
         this.waterlogged = key.waterlogged();
         this.input = EntryIngredients.ofIngredient(key.input());
         this.mesh = EntryIngredients.of(key.mesh());
-        this.outputs = outputs.outputs()
-                .entries()
-                .stream()
-                .map(entry -> Map.entry(EntryIngredients.of(entry.getKey()), entry.getValue()))
-                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Map<EntryIngredient, Double> map = new HashMap<>();
+        outputs.outputs().forEach((stack, d) -> map.put(EntryIngredients.of(stack), d));
+        this.outputs = Collections.unmodifiableMap(map);
     }
 
     @Override


### PR DESCRIPTION
This should fix the REI compatability.
The issue was caused by `SieveDisplay` throwing an error when being contructed with multiple probabilities for the same item:

`Stream.collect(...)` is throwing an `IllegalStateException: Duplicate key [TypedEntryStack]`.
As far as I can tell this is being caused because `EntryIngredient` is handled as a` List<EntryStack<?>>` while being in the stream. Because the lists always contain only a single item they are seen equal and the exception is thrown. 
When outside the stream (like in the foreach-loop) the `EntryIngredient`'s are correctly handled and no exception is thrown.