### PR TITLE
Do not issue a DDOS attack from strainers or barrels

### DIFF
--- a/src/main/java/wraith/fabricaeexnihilo/modules/barrels/BarrelBlockEntity.java
+++ b/src/main/java/wraith/fabricaeexnihilo/modules/barrels/BarrelBlockEntity.java
@@ -187,13 +187,25 @@ public class BarrelBlockEntity extends BaseBlockEntity implements EnchantableBlo
         }
         if (tickCounter <= 0) {
             tickCounter = FabricaeExNihilo.CONFIG.get().barrels().tickRate();
-            markDirty();
+            // dirty fix for https://github.com/LordDeatHunter/FabricaeExNihilo/issues/55
+            if (--dirtyTimeoutA<=0) {
+                // why do we even want to call this in tick()?
+                markDirty();
+                dirtyTimeoutA = 100;
+            }
             tickRecipe();
         } else {
             --tickCounter;
-            markDirty();
+            // dirty fix for https://github.com/LordDeatHunter/FabricaeExNihilo/issues/55
+            if (--dirtyTimeoutB<=0) {
+                // why do we even want to call this in tick()?
+                markDirty();
+                dirtyTimeoutB = 100;
+            }
         }
     }
+    private static int dirtyTimeoutA = 100;
+    private static int dirtyTimeoutB = 100;
 
     private void tickRecipe() {
         if (world == null || world.isClient) return;

--- a/src/main/java/wraith/fabricaeexnihilo/modules/strainer/StrainerBlockEntity.java
+++ b/src/main/java/wraith/fabricaeexnihilo/modules/strainer/StrainerBlockEntity.java
@@ -92,8 +92,14 @@ public class StrainerBlockEntity extends BaseBlockEntity {
             strainer.timeUntilCatch = world.random.nextBetween(config.minWaitTime(), config.maxWaitTime());
             strainer.markForUpdate();
         }
-        strainer.markDirty();
+        // dirty fix for https://github.com/LordDeatHunter/FabricaeExNihilo/issues/55
+        if (--dirtyTimeout<=0) {
+            // why do we even want to call this in tick()?
+            strainer.markDirty();
+            dirtyTimeout = 100;
+        }
     }
+    private static int dirtyTimeout = 100;
 
     private class StrainerItemStorage extends CombinedStorage<ItemVariant, StackStorage> {
         public StrainerItemStorage() {


### PR DESCRIPTION
This is a band-aid solution for #55. That issue has been effectively DDOSing our servers; and since the report is already 8 months old with no update whatsoever, we only have the option to include dirty patches for it or remove FEN entirely. We'd like to keep it; so this is a dirty fix to the already dirty implementation. LOL.